### PR TITLE
Allow duplicate item names on a shopping list

### DIFF
--- a/src/Services/ShoppingListService.cs
+++ b/src/Services/ShoppingListService.cs
@@ -177,7 +177,7 @@ namespace shopping_bag.Services
         }
 
         public async Task<ServiceResponse<Item>> ModifyItem(User user, ModifyItemDto itemToModify, long itemId) {
-            var item = await _context.Items.Include(i => i.ShoppingList).FirstOrDefaultAsync(i => i.Id == itemId);
+            var item = await _context.Items.Include(i => i.ShoppingList).ThenInclude(list => list.Items).FirstOrDefaultAsync(i => i.Id == itemId);
             var result = CanUserInteractWithItem(user, item);
             if (result == ItemStatus.NOT_FOUND || result == ItemStatus.LIST_REMOVED) {
                 return new ServiceResponse<Item>(error: "Item doesn't exist.");

--- a/tests/unit-tests/Services/ShoppingListServiceTests.cs
+++ b/tests/unit-tests/Services/ShoppingListServiceTests.cs
@@ -224,24 +224,6 @@ namespace shopping_bag_unit_tests.Services {
         }
 
         [Fact]
-        public async Task AddItem_DuplicateName_ReturnsError() {
-            SetupDb();
-
-            // Ensure service result ok
-            var result = await _sut.AddItemToShoppingList(new AddItemDto() { ShoppingListId = normalList.Id, Name = "Test item" });
-            Assert.True(result.IsSuccess);
-
-            // Ensure service result error
-            result = await _sut.AddItemToShoppingList(new AddItemDto() { ShoppingListId = normalList.Id, Name = "Test item" });
-            Assert.False(result.IsSuccess);
-            Assert.Equal("Item with same name already in list", result.Error);
-
-            // Ensure only first item added to list.
-            var list = _context.ShoppingLists.Include(s => s.Items).FirstOrDefault(s => s.Items.Count(i => i.Name == "Test item") == 1);
-            Assert.NotNull(list);
-        }
-
-        [Fact]
         public async Task AddItem_DuplicateUrl_ReturnsError() {
             SetupDb();
 
@@ -403,18 +385,6 @@ namespace shopping_bag_unit_tests.Services {
             Assert.NotNull(item);
             Assert.Equal("Test item", item.Name);
             Assert.Equal("New url", item.Url);
-        }
-
-        [Fact]
-        public async Task ModifyItem_DuplicateName_ItemNotModified() {
-            SetupDb();
-
-            var result = await _sut.ModifyItem(normalUser, new ModifyItemDto() { Name = "Test item"}, ownItemInList.Id);
-            Assert.True(result.IsSuccess);
-
-            result = await _sut.ModifyItem(normalUser, new ModifyItemDto() { Name = "Test item"}, ownItem2InList.Id);
-            Assert.False(result.IsSuccess);
-            Assert.Equal("Item with same name already in list", result.Error);
         }
 
         [Fact]


### PR DESCRIPTION
This also fixes a bug when modify item not checking that URL can be duplicate.

Closes #65 