### PR TITLE
Improve the error message when email is already in use

### DIFF
--- a/src/Services/UserService.cs
+++ b/src/Services/UserService.cs
@@ -118,6 +118,11 @@ namespace shopping_bag.Services {
 
                     if (modifyData.Email != modifyUser.Email)
                     {
+                        if (_context.Users.Any(u => u.Email == modifyData.Email))
+                        {
+                            return new ServiceResponse<User>(error: "Email already in use");
+                        }
+
                         modifyUser.Email = modifyData.Email;
                         modifyUser.VerificationToken = hexToken;
                         modifyUser.VerifiedAt = null;


### PR DESCRIPTION
**Description**
Basically adds better error message indicating that if the user has modified the email and the given email is already in use. 

Is the error message sensible? I had first something like `Account with that email already exists`, but personally I would like the error messages to be as concise as possible.

Closes #108 