### PR TITLE
Improve email messages for verify and reminders

### DIFF
--- a/src/Services/ReminderService.cs
+++ b/src/Services/ReminderService.cs
@@ -292,14 +292,14 @@ namespace shopping_bag.Services {
             foreach (var kv in remindersToSend) {
                 var sb = new StringBuilder();
                 sb.Append(StaticConfig.EmailReminderIntro);
-                sb.Append("<br>");
+                sb.Append("<h2>Notifications</h2>");
                 sb.AppendJoin("<br>", kv.Value); // List of reminders
-                sb.Append("<br>");
+                sb.Append("<br><br>");
                 sb.AppendLine(StaticConfig.EmailReminderTurnOffEmails);
                 try {
                     _emailService.SendEmail(new Models.Email.Email() {
                         To = kv.Key.Email,
-                        Subject = "TODO: subject",
+                        Subject = "Huld Shopping Bag - Reminder",
                         Body = sb.ToString()
                     });
                 }catch (Exception) {

--- a/src/appsettings.json
+++ b/src/appsettings.json
@@ -26,7 +26,7 @@
   },
   "AllowedEmailDomain": [ "@ethereal.email" ],
   "VerificationEmail": {
-    "BodyText": "You're receiving this email because you recently created an account to Huld Shopping Bag application. Please verify your account by clicking the following activation link: {0}"
+    "BodyText": "You're receiving this email because you recently created an account or changed your account email to Huld Shopping Bag application. <br>Please verify your account by clicking the following activation link: {0}"
   },
   "RecoverEmail": {
     "BodyText": "You're receiving this email because you have requested account recovery for Huld Shopping Bag application. You can use the below token to reset your account and password. <br><br> Your reset token is: <b>{0}</b>"
@@ -40,7 +40,7 @@
   "Reminders": {
     "DueDateReminderFormat": "Due date for list {0} is {1} {2}. Items should be added before the due date.",
     "ExpectedDateReminderFormat": "Expected delivery date for list {0} is {1} {2}.",
-    "EmailReminderIntro": "TODO",
-    "EmailReminderTurnOffEmails": "TODO"
+    "EmailReminderIntro": "You are receiving the email since you have subscribed for Huld Shopping Bag list notifications. At least one of your subscribed shopping list has due or expected delivery date close. <br>",
+    "EmailReminderTurnOffEmails": "<br><small>If you don't wish to get these emails, you can turn off all notifications or change the subscriptions for new lists in Account Settings page. List specific notifications can be controlled by clicking the notification bell icon.</small>"
   }
 }


### PR DESCRIPTION
**Description**
Improve mostly the reminder email format and add the intro and turn off emails things. Also, added to the verify email the case where user might have changed their email as both account creation and change use the same email template.

Closes #55

Here's an example from Ethereal so you don't need to run it yourself basically.
![etherealexample](https://user-images.githubusercontent.com/16706187/205046533-08186a51-2328-4bad-b706-229eacfd5e20.png)