### PR TITLE
Add more cleanup conditions to reminders

### DIFF
--- a/src/Config/StaticConfig.cs
+++ b/src/Config/StaticConfig.cs
@@ -26,11 +26,12 @@
         public static long DefaultAdminOfficeId { get; private set; }
         public static string[] DefaultAdminRoles { get; private set; }
         #endregion
-        #region Reminders messages
+        #region Reminders
         public static string EmailDueDateReminderFormat { get; private set; }
         public static string EmailExpectedDateReminderFormat { get; private set; }
         public static string EmailReminderIntro { get; private set; }
         public static string EmailReminderTurnOffEmails { get; private set; }
+        public static int OrderedRemindersCleanUpDays { get; private set; }
         #endregion
         public static void Setup(IConfiguration config)
         {
@@ -57,11 +58,12 @@
             DefaultAdminOfficeId = config.GetValue<long>("DefaultAdmin:OfficeId");
             DefaultAdminRoles = config.GetSection("DefaultAdmin:Roles").Get<string[]>();
             #endregion
-            #region Reminder messages
+            #region Reminders
             EmailDueDateReminderFormat = config.GetValue<string>("Reminders:DueDateReminderFormat");
             EmailExpectedDateReminderFormat = config.GetValue<string>("Reminders:ExpectedDateReminderFormat");
             EmailReminderIntro = config.GetValue<string>("Reminders:EmailReminderIntro");
             EmailReminderTurnOffEmails = config.GetValue<string>("Reminders:EmailReminderTurnOffEmails");
+            OrderedRemindersCleanUpDays = config.GetValue<int>("Reminders:OrderedRemindersCleanUpDays");
             #endregion
         }
     }

--- a/src/Services/ReminderService.cs
+++ b/src/Services/ReminderService.cs
@@ -270,6 +270,16 @@ namespace shopping_bag.Services {
                         continue;
                     }
 
+                    // If list is ordered and expected delivery date is X days in the past, remove reminder and settings.
+                    if(reminder.ShoppingList.Ordered && reminder.ShoppingList.ExpectedDeliveryDate.HasValue 
+                        && reminder.ShoppingList.ExpectedDeliveryDate.Value > DateTime.Now
+                        && (reminder.ShoppingList.ExpectedDeliveryDate.Value - DateTime.Now).Days >= StaticConfig.OrderedRemindersCleanUpDays) {
+                        reminder.User.Reminders.Remove(reminder);
+                        reminder.User.ListReminderSettings.RemoveAll(r => r.ShoppingListId == list.Id);
+                        await _context.SaveChangesAsync(stoppingToken);
+                        continue;
+                    }
+
                     // If both settings null or both disabled, remove reminder.
                     if ((settings == null || (settings.DueDateRemindersDisabled && settings.ExpectedRemindersDisabled)) &&
                             (listSettings == null || (listSettings.DueDateRemindersDisabled && listSettings.ExpectedRemindersDisabled))) {

--- a/src/appsettings.json
+++ b/src/appsettings.json
@@ -41,6 +41,7 @@
     "DueDateReminderFormat": "Due date for list {0} is {1} {2}. Items should be added before the due date.",
     "ExpectedDateReminderFormat": "Expected delivery date for list {0} is {1} {2}.",
     "EmailReminderIntro": "You are receiving the email since you have subscribed for Huld Shopping Bag list notifications. At least one of your subscribed shopping list has due or expected delivery date close. <br>",
-    "EmailReminderTurnOffEmails": "<br><small>If you don't wish to get these emails, you can turn off all notifications or change the subscriptions for new lists in Account Settings page. List specific notifications can be controlled by clicking the notification bell icon.</small>"
+    "EmailReminderTurnOffEmails": "<br><small>If you don't wish to get these emails, you can turn off all notifications or change the subscriptions for new lists in Account Settings page. List specific notifications can be controlled by clicking the notification bell icon.</small>",
+    "OrderedRemindersCleanUpDays": 14
   }
 }


### PR DESCRIPTION
There's probably many more possible conditions but this should catch most of the reminders that are left in the db after no more reminders are possible for the list.

Closes #119 