### PR TITLE
Return GetShoppingListById when adding shopping list

### DIFF
--- a/src/Services/ShoppingListService.cs
+++ b/src/Services/ShoppingListService.cs
@@ -33,7 +33,7 @@ namespace shopping_bag.Services
             {
                 return new ServiceResponse<ShoppingList>(error: "Active shopping list with that name already exists.");
             }
-
+            
             try
             {
                 {
@@ -52,7 +52,7 @@ namespace shopping_bag.Services
                     await _context.SaveChangesAsync();
                     await _reminderService.CreateRemindersForList(shoppingList.Id, shoppingListData.OfficeId);
 
-                    return new ServiceResponse<ShoppingList>(data: shoppingList);
+                    return await GetShoppingListById(shoppingList.Id);
                 }
             }
             catch (Exception ex)


### PR DESCRIPTION
**Description**
So there was a minor bug when adding a shopping list to another office than homeoffice. After adding the list didn't show up there as `ListDeliveryOffice` was not returned. This should now fix it. 

Other things should now use this `Get...ById()` thing and similar bugs shouldn't arise any more, right?